### PR TITLE
Allows for --harmony_default_parameters transfer to node.

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -34,6 +34,7 @@ module.exports = ( sScript, oOptions = {} ) ->
     aOptions.push "--debug" if oOptions.debug is yes
     aOptions.push "--debug-brk" if oOptions.debugBrk is yes
     aOptions.push "--harmony" if oOptions.harmony is yes
+    aOptions.push "--harmony_default_parameters" if oOptions.harmony_default_parameters is yes
     aOptions.push "--force-watch" if oOptions.forceWatch is yes
     aOptions.push "--quiet" if oOptions.quiet is yes
 
@@ -41,4 +42,3 @@ module.exports = ( sScript, oOptions = {} ) ->
     aOptions.push oOptions.args... if kindOf( oOptions.args ) is "array"
 
     supervisor.run aOptions
-

--- a/index.js
+++ b/index.js
@@ -57,6 +57,9 @@ module.exports = function(sScript, oOptions) {
   if (oOptions.harmony === true) {
     aOptions.push("--harmony");
   }
+  if (oOptions.harmony_default_parameters === true) {
+    aOptions.push("--harmony_default_parameters");
+  }
   if (oOptions.forceWatch === true) {
     aOptions.push("--force-watch");
   }


### PR DESCRIPTION
It is necessary for ES6 default parameters support in node 5.5.0.
Default parameters will be enable by default in node 6.
